### PR TITLE
Move premiere, written, and print `dates` to `standOff` element

### DIFF
--- a/level1/Babits_ALiterator.xml
+++ b/level1/Babits_ALiterator.xml
@@ -123,9 +123,6 @@
                     </author>
                     <title type="main">A literátor</title>
                     <title type="sub">Érzékenyjáték egy felvonásban</title>
-                    <date type="print" when="1916">1916. december 16.</date>
-                    <date type="premiere"/>
-                    <date type="written">1916. december 16.</date>
                     <pubPlace>Budapest</pubPlace>
                     <publisher>Nyugat</publisher>
                 </bibl>
@@ -180,6 +177,13 @@
             </particDesc>
         </profileDesc>
     </teiHeader>
+    <standOff>
+        <listEvent>
+            <event type="print" when="1916">
+                <label>1916. december 16.</label>
+            </event>
+        </listEvent>
+    </standOff>
     <text>
         <front>
             <castList>

--- a/level1/Babits_AMasodikEnek.xml
+++ b/level1/Babits_AMasodikEnek.xml
@@ -122,9 +122,6 @@
                         <idno type="wikidata">Q332482</idno>
                     </author>
                     <title type="main">A második ének</title>
-                    <date type="print" when="1942">1942</date>
-                    <date type="premiere">unknown</date>
-                    <date type="written">unknown</date>
                     <pubPlace>Budapest</pubPlace>
                     <publisher>Nyugat</publisher>
                 </bibl>
@@ -341,6 +338,11 @@
             </particDesc>
         </profileDesc>
     </teiHeader>
+    <standOff>
+        <listEvent>
+            <event type="print" when="1942"><desc/></event>
+        </listEvent>
+    </standOff>
     <text>
         <body>
             <div type="act">

--- a/level1/Babits_ASimoneHaza.xml
+++ b/level1/Babits_ASimoneHaza.xml
@@ -133,9 +133,6 @@
                     </respStmt>
                     <title type="main">A Simóné háza</title>
                     <title type="sub">Falusi tragédia / Színmű egy felvonásban</title>
-                    <date type="print" when="1978">1978</date>
-                    <date type="premiere"/>
-                    <date type="written"/>
                     <pubPlace>Budapest</pubPlace>
                     <publisher>Ságvári Nyomdaip. Szakközépisk. és Szakmunkásképző Int.;
                         Athenaeum</publisher>
@@ -190,6 +187,11 @@
             </textClass>
         </profileDesc>
     </teiHeader>
+    <standOff>
+        <listEvent>
+            <event type="print" when="1978"><desc/></event>
+        </listEvent>
+    </standOff>
     <text>
         <front>
             <castList>

--- a/level1/Babits_Laodameia.xml
+++ b/level1/Babits_Laodameia.xml
@@ -129,9 +129,6 @@
                     </author>
                     <title type="main">Laodameia</title>
                     <title type="sub"/>
-                    <date type="print" when="1910">1910</date>
-                    <date type="premiere" when="1983">1983. november 27.</date>
-                    <date type="written" when="1910">1910</date>
                     <pubPlace>Budapest</pubPlace>
                     <publisher>Nyugat</publisher>
                 </bibl>
@@ -174,6 +171,13 @@
             </particDesc>
         </profileDesc>
     </teiHeader>
+    <standOff>
+        <listEvent>
+            <event type="print" when="1910"><desc/></event>
+            <event type="premiere" when="1983"><label>1983. november 27.</label></event>
+            <event type="written" when="1910"><desc/></event>
+        </listEvent>
+    </standOff>
     <text>
         <front>
             <castList>

--- a/level1/Balassi_SzepMagyarKomedia.xml
+++ b/level1/Balassi_SzepMagyarKomedia.xml
@@ -126,9 +126,6 @@
 						<idno type="wikidata">Q379599</idno>
 					</author>
 					<title type="main">Szép magyar komédia</title>
-					<date type="print" when="1656">1656</date>
-					<date type="premiere">unknown</date>
-					<date type="written" when="1589">1589</date>
 					<publisher>unknown</publisher>
 					<pubPlace>unknown</pubPlace>
 				</bibl>
@@ -171,6 +168,12 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1656"><desc/></event>
+			<event type="written" when="1589"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Balazs_AKekszakalluHercegVara.xml
+++ b/level1/Balazs_AKekszakalluHercegVara.xml
@@ -124,9 +124,6 @@
                     </author>
                     <title type="main">Misztériumok</title>
                     <title type="sub">Három egyfelvonásos</title>
-                    <date type="print" when="1912">1912</date>
-                    <date type="premiere" when="1918-05-24">1918-05-24</date>
-                    <date type="written" when="1910">1910</date>
                     <pubPlace>Budapest</pubPlace>
                     <publisher>Nyugat</publisher>
                 </bibl>
@@ -156,6 +153,13 @@
             </textClass>
         </profileDesc>
     </teiHeader>
+    <standOff>
+        <listEvent>
+            <event type="print" when="1912"><desc/></event>
+            <event type="premiere" when="1918-05-24"><desc/></event>
+            <event type="written" when="1910"><desc/></event>
+        </listEvent>
+    </standOff>
     <text>
         <front>
             <castList>

--- a/level1/Balazs_HalalosFiatalsag.xml
+++ b/level1/Balazs_HalalosFiatalsag.xml
@@ -116,9 +116,6 @@
             <idno type="wikidata">Q469963</idno>
           </author>
           <title type="main">Halálos fiatalság</title>
-          <date type="print" when="1917">1917</date>
-          <date type="premiere" when="1918">1918</date>
-          <date type="written" when="1917">1917</date>
           <pubPlace>Gyoma</pubPlace>
           <publisher>Kner Izidor Könyvnyomdájában</publisher>
         </bibl>
@@ -155,6 +152,13 @@
       </particDesc>
     </profileDesc>
   </teiHeader>
+  <standOff>
+    <listEvent>
+      <event type="print" when="1917"><desc/></event>
+      <event type="premiere" when="1918"><desc/></event>
+      <event type="written" when="1917"><desc/></event>
+    </listEvent>
+  </standOff>
   <text>
     <front>
       <castList>

--- a/level1/Balazs_Hazateres.xml
+++ b/level1/Balazs_Hazateres.xml
@@ -121,9 +121,6 @@
 					</author>
 					<title type="main">Hazatérés</title>
 					<title type="sub">Dráma 4 felvonásban, 7 képben</title>
-					<date type="print" when="1941">1941</date>
-					<date type="premiere">unknown</date>
-					<date type="written" when="1941">1941</date>
 					<pubPlace>Moszkva</pubPlace>
 					<publisher>Mezsdunarodnaja Kniga Nemzetközi Könyv</publisher>
 				</bibl>
@@ -256,6 +253,12 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1941"><desc/></event>
+      <event type="written" when="1941"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Balazs_Mozart.xml
+++ b/level1/Balazs_Mozart.xml
@@ -121,9 +121,6 @@
 					</author>
 					<title type="main">Mozart</title>
 					<title type="sub"/>
-					<date type="print" when="1941">1941</date>
-					<date type="premiere" when="1946-03-14">1946-03-14</date>
-					<date type="written" when="1938">1938</date>
 					<pubPlace>Moszkva</pubPlace>
 					<publisher>Mezsdunarodnaja Kniga Nemzetközi Könyv</publisher>
 				</bibl>
@@ -247,6 +244,13 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1941"><desc/></event>
+			<event type="premiere" when="1946-03-14"><desc/></event>
+			<event type="written" when="1938"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Berczik_APozsonyiDieta.xml
+++ b/level1/Berczik_APozsonyiDieta.xml
@@ -127,9 +127,6 @@
 					</author>
 					<title type="main">A pozsonyi diéta</title>
 					<title type="sub">Vígjáték</title>
-					<date type="print" when="1908">1908</date>
-					<date type="premiere" when="1907-11-09">1907-11-09</date>
-					<date type="written" when="1907">1907</date>
 					<pubPlace>Budapest</pubPlace>
 					<publisher>Franklin</publisher>
 				</bibl>
@@ -237,6 +234,13 @@
 			</textClass>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1908"><desc/></event>
+			<event type="premiere" when="1907-11-09"><desc/></event>
+			<event type="written" when="1907"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Bessenyei_AFilosofus.xml
+++ b/level1/Bessenyei_AFilosofus.xml
@@ -118,9 +118,6 @@
 					</author>
 					<title type="main"/>
 					<title type="sub"/>
-					<date type="print" when="1777">1777</date>
-					<date type="premiere"/>
-					<date type="written"/>
 					<pubPlace>Pest</pubPlace>
 					<publisher/>
 				</bibl>
@@ -166,6 +163,11 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1777"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Bessenyei_AFilosofus.xml
+++ b/level1/Bessenyei_AFilosofus.xml
@@ -191,7 +191,7 @@
 						Titzius’.</role>
 				</castItem>
 				<castItem>
-					<role><roleName>Lilisz</roleName>, Name>Nemes ifjú.</role>
+					<role><roleName>Lilisz</roleName>, Nemes ifjú.</role>
 				</castItem>
 				<castItem>
 					<role><roleName>Angyelika</roleName>, Párménió’ testvér húga, Lilisz

--- a/level1/Bessenyei_AgisTragediaja.xml
+++ b/level1/Bessenyei_AgisTragediaja.xml
@@ -126,9 +126,6 @@
 					</author>
 					<title type="main"/>
 					<title type="sub"/>
-					<date type="print" when="1776"/>
-					<date type="premiere"/>
-					<date type="written"/>
 					<pubPlace>Bécs</pubPlace>
 					<publisher/>
 				</bibl>
@@ -179,6 +176,11 @@
 			</textClass>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1776"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Bessenyei_BudaTragediaja.xml
+++ b/level1/Bessenyei_BudaTragediaja.xml
@@ -136,9 +136,6 @@
 					</author>
 					<title type="main">Buda tragédiája</title>
 					<title type="sub"/>
-					<date type="print" when="1773">1773</date>
-					<date type="premiere">unknown</date>
-					<date type="written" when="1773">1773</date>
 					<pubPlace>Posony</pubPlace>
 					<publisher>Landerer</publisher>
 				</bibl>
@@ -192,6 +189,12 @@
 			</textClass>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1773"><desc/></event>
+			<event type="written" when="1773"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Bessenyei_HunyadiLaszloTragediaja.xml
+++ b/level1/Bessenyei_HunyadiLaszloTragediaja.xml
@@ -113,7 +113,6 @@
 						</persName>
 						<idno type="wikidata"/>
 					</author>
-					<date type="print" when="1772">1772</date>
 					<pubPlace>Bécs</pubPlace>
 					<publisher/>
 				</bibl>
@@ -127,9 +126,6 @@
 					</author>
 					<title type="main">Hunyadi László tragédiája</title>
 					<title type="sub"/>
-					<date type="print">1778</date>
-					<date type="premiere"/>
-					<date type="written"/>
 					<pubPlace/>
 					<publisher/>
 				</bibl>
@@ -180,6 +176,11 @@
 			</textClass>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1772"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Bessenyei_Lais.xml
+++ b/level1/Bessenyei_Lais.xml
@@ -115,8 +115,6 @@
 						</persName>
 						<idno type="wikidata">Q794046</idno>
 					</author>
-					<date type="written" notBefore="1772" notAfter="1810"/>
-					<date type="print" when="1899"/>
 					<pubPlace/>
 					<publisher/>
 				</bibl>
@@ -131,9 +129,6 @@
 					<title type="main">Lais</title>
 					<title type="sub">vagy az erkölcsi makacs Komédia, öt játékban, versekben
                         Bessenyei György által </title>
-					<date type="print"/>
-					<date type="premiere"/>
-					<date type="written"/>
 					<pubPlace/>
 					<publisher/>
 				</bibl>
@@ -178,6 +173,12 @@
 			</textClass>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="written" notBefore="1772" notAfter="1810"><desc/></event>
+			<event type="print" when="1899"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Bormenisza_TragoediaMagyarNyelven.xml
+++ b/level1/Bormenisza_TragoediaMagyarNyelven.xml
@@ -131,9 +131,6 @@
 						</persName>
 						<idno type="wikidata">Q835071</idno>
 					</author>
-					<date type="print" when="1558">1558</date>
-					<date type="premiere" when="1931-03-02">1931-03-02</date>
-					<date type="written" when="1558">1558</date>
 					<pubPlace>Bécs</pubPlace>
 					<publisher/>
 				</bibl>
@@ -173,6 +170,13 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1558"><desc/></event>
+			<event type="premiere" when="1931-03-02"><desc/></event>
+			<event type="written" when="1558"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<head>AZ JÁTÉKBA ELÖLJÁRÓ BESZÉD</head>

--- a/level1/Brody_ATanitono.xml
+++ b/level1/Brody_ATanitono.xml
@@ -123,9 +123,6 @@
 					</author>
 					<title type="main">A tanítónő</title>
 					<title type="sub">Falusi életkép három felvonásban</title>
-					<date type="print" when="1908">1908</date>
-					<date type="premiere" when="1908-03-21">1908. március 21.</date>
-					<date type="written" to="1907" from="1908">1908</date>
 					<pubPlace>Budapest</pubPlace>
 					<publisher>Singer - Wolfner</publisher>
 				</bibl>
@@ -231,6 +228,12 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1908"><desc/></event>
+			<event type="premiere" when="1908-03-21"><label>1908. március 21.</label></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Csath_AJanika.xml
+++ b/level1/Csath_AJanika.xml
@@ -890,7 +890,7 @@
 						acutissima. Harminckilenc és hattized temperatúra. Most diagnosztizáltam.
 						Tehát rögtön jössz. Hozd magaddal Patakyt, vagy értesítsd előbb telefonon,
 						ha nincs otthon, akkor Horváthot.<stage>(Az asszony keresztülmegy a szobán,
-							utána a szakácsnő mosdótálat visz tele vízzel.)</stage>>Tehát rögtön
+							utána a szakácsnő mosdótálat visz tele vízzel.)</stage> Tehát rögtön
 						indulsz, Pertics Jenő úr fia, József utca 17., II. emelet. Hányas szám,
 						kérem?...</p>
 				</sp>
@@ -2098,7 +2098,7 @@
 							lógó két nagy olajnyomatra mutat)</stage>, amiket részletfizetésre
 						vettél. Visszaadjuk a kanapépárnát, a nagy levélszekrényt, a tíz-tíz
 						forintot, amit betettél a gyerekek születésnapján a takarékba. Máma kivettem
-						a pénzt. Íme, átadom.<stage>(Tárcát vesz elő.)</stage>>Húsz, negyven, hatvan
+						a pénzt. Íme, átadom.<stage>(Tárcát vesz elő.)</stage> Húsz, negyven, hatvan
 							korona.<stage>(Kiteszi a bankókat az asztal közepére.)</stage>Vissza
 						fogjuk adni<stage>(tovább olvas)</stage>a lábszőnyeget, az ezüst diótörőt és
 						a pálinkáskészletet is.<stage>(Iszik.)</stage>Visszaadjuk, amit a

--- a/level1/Csath_AJanika.xml
+++ b/level1/Csath_AJanika.xml
@@ -117,9 +117,6 @@
 						</persName>
 						<idno type="wikidata">Q469956</idno>
 					</author>
-					<date type="print" when="1911">1911</date>
-					<date type="premiere" when="1911-05-20">1911-05-20</date>
-					<date type="written" when="1911">1911</date>
 					<pubPlace>Budapest</pubPlace>
 					<publisher>Nyugat</publisher>
 				</bibl>
@@ -171,6 +168,13 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1911"><desc/></event>
+			<event type="premiere" when="1911-05-20"><desc/></event>
+			<event type="written" when="1911"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Csath_Hamvazoszerda.xml
+++ b/level1/Csath_Hamvazoszerda.xml
@@ -141,9 +141,6 @@
 						</persName>
 					</respStmt>
 					<title>Hamvazószerda</title>
-					<date type="print" when="1974">1974</date>
-					<date type="premiere" when="1911">1911</date>
-					<date type="written" when="1911">1911</date>
 					<pubPlace>Gyoma</pubPlace>
 					<publisher>Kner Ny.</publisher>
 				</bibl>
@@ -285,6 +282,13 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1974"><desc/></event>
+			<event type="premiere" when="1911"><desc/></event>
+			<event type="written" when="1911"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Csiky_AJoFulop.xml
+++ b/level1/Csiky_AJoFulop.xml
@@ -127,9 +127,6 @@
 					</author>
 					<title type="main">A jó Fülöp</title>
 					<title type="sub">Vígjáték három felvonásban</title>
-					<date type="print" when="1887">1887</date>
-					<date type="premiere" when="1887-01-07">1887-01-07</date>
-					<date type="written" when="1886">1886</date>
 					<pubPlace>Budapest</pubPlace>
 					<publisher>Athenaeum</publisher>
 				</bibl>
@@ -186,6 +183,13 @@
 			</textClass>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1887"><desc/></event>
+			<event type="premiere" when="1887-01-07"><desc/></event>
+			<event type="written" when="1886"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Csiky_AKaviar.xml
+++ b/level1/Csiky_AKaviar.xml
@@ -121,9 +121,6 @@
               <forename>Gergely</forename>
             </persName>
             <idno type="wikidata"/>Q166952 </author>
-          <date type="print" when="1884">1884</date>
-          <date type="premiere" when="1882">1882</date>
-          <date type="written" when="1882">1882</date>
           <pubPlace>Budapest</pubPlace>
           <publisher>Athenaeum</publisher>
         </bibl>
@@ -204,6 +201,13 @@
       </textClass>
     </profileDesc>
   </teiHeader>
+  <standOff>
+    <listEvent>
+      <event type="print" when="1884"><desc/></event>
+      <event type="premiere" when="1882"><desc/></event>
+      <event type="written" when="1882"><desc/></event>
+    </listEvent>
+  </standOff>
   <text>
     <front>
       <castList>

--- a/level1/Csiky_ANagymama.xml
+++ b/level1/Csiky_ANagymama.xml
@@ -128,9 +128,6 @@
 						<idno type="wikidata">Q166952</idno>
 					</author>
 					<title>A nagymama</title>
-					<date type="print" when="1891">1891</date>
-					<date type="premiere" when="1891">1891</date>
-					<date type="written" when="1891">1891</date>
 					<publisher>Franklin</publisher>
 					<pubPlace>Budapest</pubPlace>
 				</bibl>
@@ -206,6 +203,13 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1891"><desc/></event>
+			<event type="premiere" when="1891"><desc/></event>
+			<event type="written" when="1891"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Csiky_AProletarok.xml
+++ b/level1/Csiky_AProletarok.xml
@@ -116,9 +116,6 @@
 					</author>
 					<title type="main">A proletárok</title>
 					<title type="sub">Színmű 4. felv.</title>
-					<date type="print" when="1882">1882</date>
-					<date type="premiere" when="1880">1880-01-23</date>
-					<date type="written" when="1880">1880</date>
 					<pubPlace>Budapest</pubPlace>
 					<publisher>Athenaeum</publisher>
 				</bibl>
@@ -197,6 +194,13 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1882"><desc/></event>
+			<event type="premiere" when="1880"><label>1880-01-23</label></event>
+			<event type="written" when="1880"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Csiky_AVasember.xml
+++ b/level1/Csiky_AVasember.xml
@@ -127,9 +127,6 @@
 						</persName>
 						<idno type="wikidata">Q166952</idno>
 					</author>
-					<date type="print" when="1888">1888</date>
-					<date type="premiere" when="1888">1888</date>
-					<date type="written" when="1888">1888</date>
 					<pubPlace>Budapest</pubPlace>
 					<publisher>Athenaeum</publisher>
 				</bibl>
@@ -169,6 +166,13 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1888"><desc/></event>
+			<event type="premiere" when="1888"><desc/></event>
+			<event type="written" when="1888"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<!-- ehhez vissza kell térni -->

--- a/level1/Csiky_Buborekok.xml
+++ b/level1/Csiky_Buborekok.xml
@@ -1146,7 +1146,7 @@
 					<sp who="#szidonia">
 						<speaker>SZIDÓNIA</speaker>
 						<p>Életemnek legszebb napja ez. Saját esküvőm óta nem voltam ily
-								boldog.<stage>(Solmayhoz)</stage>>Csókolj meg, édesem.</p>
+								boldog.<stage>(Solmayhoz)</stage> Csókolj meg, édesem.</p>
 					</sp>
 					<sp who="#solmay_ignac">
 						<speaker>SOLMAY</speaker>

--- a/level1/Csiky_Buborekok.xml
+++ b/level1/Csiky_Buborekok.xml
@@ -124,9 +124,6 @@
 							<forename/>
 						</persName>
 					</respStmt>
-					<date type="print" when="1885">1885</date>
-					<date type="premiere" when="1884">1884</date>
-					<date type="written" when="1884">1884</date>
 					<pubPlace>Budapest</pubPlace>
 					<publisher>Athenaeum R.</publisher>
 				</bibl>
@@ -210,6 +207,13 @@
 			</textClass>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1885"><desc/></event>
+			<event type="premiere" when="1884"><desc/></event>
+			<event type="written" when="1884"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Csiky_SzepLeanyok.xml
+++ b/level1/Csiky_SzepLeanyok.xml
@@ -125,9 +125,6 @@
 					</author>
 					<title type="main">Szép leányok</title>
 					<title type="sub">Színmű</title>
-					<date type="print" when="1882">1882</date>
-					<date type="premiere" when="1882-05-04">1882-05-04</date>
-					<date type="written" when="1882">1882</date>
 					<pubPlace>Budapest</pubPlace>
 					<publisher>Athenaeum</publisher>
 				</bibl>
@@ -269,6 +266,13 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1882"><desc/></event>
+			<event type="premiere" when="1882-05-04"><desc/></event>
+			<event type="written" when="1882"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Csokonai_AMelaTempefoi.xml
+++ b/level1/Csokonai_AMelaTempefoi.xml
@@ -137,9 +137,6 @@
 					<title type="main">A méla Tempefői ; Gerson du Malheureux ; A cultura ;
                         Karnyóné</title>
 					<title type="sub"/>
-					<date type="print" when="1956">1956</date>
-					<date type="premiere" when="1938">1938</date>
-					<date type="written" when="1793">1793</date>
 					<pubPlace>Budapest</pubPlace>
 					<publisher>Szépirodalmi Kiadó</publisher>
 				</bibl>
@@ -209,6 +206,13 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1956"><desc/></event>
+			<event type="premiere" when="1938"><desc/></event>
+			<event type="written" when="1793"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Csokonai_AzOzvegyKarnyone.xml
+++ b/level1/Csokonai_AzOzvegyKarnyone.xml
@@ -122,9 +122,6 @@
 						</persName>
 						<idno type="wikidata">Q713545</idno>
 					</author>
-					<date type="print" when="1911">1911</date>
-					<date type="premiere" when="1911-01-29">1911-01-29</date>
-					<date type="written" when="1799">1799</date>
 					<pubPlace>Budapest</pubPlace>
 					<publisher>Nyugat: Nyugat Könyvtár</publisher>
 				</bibl>
@@ -176,6 +173,13 @@
 			</textClass>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1911"><desc/></event>
+			<event type="premiere" when="1911-01-29"><desc/></event>
+			<event type="written" when="1799"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Csokonai_Cultura.xml
+++ b/level1/Csokonai_Cultura.xml
@@ -141,9 +141,6 @@
                             <forename>József</forename>
                         </persName>
                     </respStmt>
-                    <date type="print" when="1922">1922</date>
-                    <date type="premiere" when="1799-07-12">1997-07-12</date>
-                    <date type="written" when="1799">1799</date>
                     <pubPlace>Budapest</pubPlace>
                     <publisher>Genius Kiadás</publisher>
                 </bibl>
@@ -194,6 +191,13 @@
             </textClass>
         </profileDesc>
     </teiHeader>
+    <standOff>
+        <listEvent>
+            <event type="print" when="1922"><desc/></event>
+            <event type="premiere" when="1799-07-12"><label>1997-07-12</label></event>
+            <event type="written" when="1799"><desc/></event>
+        </listEvent>
+    </standOff>
     <text>
         <front>
             <castList>

--- a/level1/Czako_KalmarEsTengeresz.xml
+++ b/level1/Czako_KalmarEsTengeresz.xml
@@ -116,9 +116,6 @@
 						</persName>
 						<idno type="wikidata">Q832280</idno>
 					</author>
-					<date type="print" when="1845">1845</date>
-					<date type="premiere" when="1844-11-18">1844 november 18.</date>
-					<date type="written" when="1844">1844</date>
 					<pubPlace>Pest</pubPlace>
 					<publisher>Trattner-Károlyi</publisher>
 				</bibl>
@@ -176,6 +173,13 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1845"><desc/></event>
+			<event type="premiere" when="1844-11-18"><label>1844 november 18.</label></event>
+			<event type="written" when="1844"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Gardonyi_ABor.xml
+++ b/level1/Gardonyi_ABor.xml
@@ -125,9 +125,6 @@
 						</persName>
 						<idno type="wikidata">Q221903</idno>
 					</author>
-					<date type="print" when="1880">1880</date>
-					<date type="premiere" when="1901-03-29">1901-03-29</date>
-					<date type="written" when="1901">1901</date>
 					<pubPlace>Budapest</pubPlace>
 					<publisher>Singer - Wolfner</publisher>
 				</bibl>
@@ -203,6 +200,13 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1880"><desc/></event>
+			<event type="premiere" when="1901-03-29"><desc/></event>
+			<event type="written" when="1901"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Hevesi_CsaszarEsKomedias.xml
+++ b/level1/Hevesi_CsaszarEsKomedias.xml
@@ -120,9 +120,6 @@
 					</author>
 					<title type="main">Császár és komédiás</title>
 					<title type="sub">Dráma négy felvonásban</title>
-					<date type="print" when="1919">1919</date>
-					<date type="premiere" when="1919">1919</date>
-					<date type="written" when="1919">1919</date>
 					<pubPlace>Budapest</pubPlace>
 					<publisher>Athenaeum Kiadó</publisher>
 				</bibl>
@@ -204,6 +201,13 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1919"><desc/></event>
+			<event type="premiere" when="1919"><desc/></event>
+			<event type="written" when="1919"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Hugo_BankarEsBaro.xml
+++ b/level1/Hugo_BankarEsBaro.xml
@@ -117,9 +117,6 @@
 					</author>
 					<title type="main">Bankár és báró</title>
 					<title type="sub">Szomorújáték három felvonásban</title>
-					<date type="print" when="1848">1848</date>
-					<date type="premiere" when="1846">1846</date>
-					<date type="written" when="1846">1846</date>
 					<pubPlace>Pest</pubPlace>
 					<publisher>Heckenast</publisher>
 				</bibl>
@@ -147,6 +144,13 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1848"><desc/></event>
+			<event type="premiere" when="1846"><desc/></event>
+			<event type="written" when="1846"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Hunyady_AHaromSarkany.xml
+++ b/level1/Hunyady_AHaromSarkany.xml
@@ -125,9 +125,6 @@
 					</author>
 					<title type="main">Lovagias ügy</title>
 					<title type="sub">Válogatott drámák</title>
-					<date type="print" when="2003">2003</date>
-					<date type="premiere" when="1936-02-16">1935-02-16</date>
-					<date type="written" when="1935">1935</date>
 					<pubPlace>Budapest</pubPlace>
 					<publisher>Európa Könyvkiadó</publisher>
 				</bibl>
@@ -221,6 +218,13 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="2003"><desc/></event>
+			<event type="premiere" when="1936-02-16"><label>1935-02-16</label></event>
+			<event type="written" when="1935"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Hunyady_Bakaruhaban.xml
+++ b/level1/Hunyady_Bakaruhaban.xml
@@ -125,9 +125,6 @@
 					</author>
 					<title type="main">Lovagias ügy</title>
 					<title type="sub">Válogatott drámák</title>
-					<date type="print" when="2003">2003</date>
-					<date type="premiere">unknown</date>
-					<date type="written" when="1931">1931</date>
 					<pubPlace>Budapest</pubPlace>
 					<publisher>Európa Könyvkiadó</publisher>
 				</bibl>
@@ -167,6 +164,12 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="2003"><desc/></event>
+			<event type="written" when="1931"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Hunyady_FeketeszaruCseresznye.xml
+++ b/level1/Hunyady_FeketeszaruCseresznye.xml
@@ -127,9 +127,6 @@
 					</author>
 					<title type="main">Feketeszárú cseresznye</title>
 					<title type="sub">Színjáték</title>
-					<date type="print" when="1930">1930</date>
-					<date type="premiere" when="1930-11-06">1930-11-06</date>
-					<date type="written" when="1930">1930</date>
 					<pubPlace>Kolozsvár</pubPlace>
 					<publisher>Erdélyi Szépmíves Céh; Concordia Ny.</publisher>
 				</bibl>
@@ -217,6 +214,13 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1930"><desc/></event>
+			<event type="premiere" when="1930-11-06"><desc/></event>
+			<event type="written" when="1930"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>
@@ -2306,7 +2310,7 @@
                         háziak az ablakhoz állnak. A hölgyek lobogtatják a kendőjüket</stage>
 					<stage>FÜGGÖNY</stage>
 				</div>
-			</div>	
+			</div>
 			<div type="act">
 				<head type="title">MÁSODIK FELVONÁS</head>
 				<head type="title">ELSŐ KÉP</head>

--- a/level1/Hunyady_JuliusiEjszaka.xml
+++ b/level1/Hunyady_JuliusiEjszaka.xml
@@ -125,9 +125,6 @@
 					</author>
 					<title type="main">Színázi Élet hetilap</title>
 					<title type="sub">7. szám, melléklet</title>
-					<date type="print" when="1930">1930</date>
-					<date type="premiere" when="1929-12-31">1929-12-31</date>
-					<date type="written" when="1929">1929</date>
 					<pubPlace>Budapest</pubPlace>
 					<publisher>Színházi Élet folyóirat</publisher>
 				</bibl>
@@ -181,6 +178,13 @@
 			</textClass>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1930"><desc/></event>
+			<event type="premiere" when="1929-12-31"><desc/></event>
+			<event type="written" when="1929"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Hunyady_KartyazoAsszonyok.xml
+++ b/level1/Hunyady_KartyazoAsszonyok.xml
@@ -127,9 +127,6 @@
 					</author>
 					<title type="main">Lovagias ügy</title>
 					<title type="sub">Válogatott drámák</title>
-					<date type="print" when="2003">2003</date>
-					<date type="premiere" when="1939-11-08">1939-11-08</date>
-					<date type="written" when="1939">1939</date>
 					<pubPlace>Budapest</pubPlace>
 					<publisher>Európa Könyvkiadó</publisher>
 				</bibl>
@@ -217,6 +214,13 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="2003"><desc/></event>
+			<event type="premiere" when="1939-11-08"><desc/></event>
+			<event type="written" when="1939"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Hunyady_LovagiasUgy.xml
+++ b/level1/Hunyady_LovagiasUgy.xml
@@ -127,9 +127,6 @@
 					</author>
 					<title type="main">Lovagias ügy</title>
 					<title type="sub"/>
-					<date type="print" when="1935">1935</date>
-					<date type="premiere" when="1935-03-23">1935-03-23</date>
-					<date type="written" when="1935">1935</date>
 					<pubPlace>Budapest</pubPlace>
 					<publisher>Színházi Élet folyóirat</publisher>
 				</bibl>
@@ -178,6 +175,13 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1935"><desc/></event>
+			<event type="premiere" when="1935-03-23"><desc/></event>
+			<event type="written" when="1935"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Hunyady_NyariZapor.xml
+++ b/level1/Hunyady_NyariZapor.xml
@@ -128,9 +128,6 @@
 							<forename>Sándor</forename>
 						</persName>
 					</respStmt>
-					<date type="print" when="1941">1941</date>
-					<date type="premiere">unknown</date>
-					<date type="written" when="1941">1941</date>
 					<pubPlace>Budapest</pubPlace>
 					<publisher>Hindy András</publisher>
 				</bibl>
@@ -184,6 +181,12 @@
 			</textClass>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1941"><desc/></event>
+			<event type="written" when="1941"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Jokai_ASzigetvariVertanuk.xml
+++ b/level1/Jokai_ASzigetvariVertanuk.xml
@@ -128,9 +128,6 @@
                     </author>
                     <title type="main">A szigetvári vértanúkban</title>
                     <title type="sub">Eredeti szomorújáték négy felvonásban</title>
-                    <date type="print" when="1843"/>
-                    <date type="premiere" when="1860">1860 március 29.</date>
-                    <date type="written" when="1860">1860</date>
                     <pubPlace>Budapest</pubPlace>
                     <publisher>Akadémiai Kiadó</publisher>
                 </bibl>
@@ -260,6 +257,13 @@
             </particDesc>
         </profileDesc>
     </teiHeader>
+    <standOff>
+        <listEvent>
+            <event type="print" when="1843"><desc/></event>
+            <event type="premiere" when="1860"><label>1860 március 29.</label></event>
+            <event type="written" when="1860"><desc/></event>
+        </listEvent>
+    </standOff>
     <text>
         <front>
             <castList>

--- a/level1/Jokai_Dalma.xml
+++ b/level1/Jokai_Dalma.xml
@@ -143,9 +143,6 @@
                     </author>
                     <title type="main">Színművek 3. kötet</title>
                     <title type="sub">Dalma; A murányi hölgy</title>
-                    <date type="print" when="1860">1860</date>
-                    <date type="premiere" when="1852-11-27">1852-11-27</date>
-                    <date type="written" when="1852">1852</date>
                     <pubPlace>Pest</pubPlace>
                     <publisher/>
                 </bibl>
@@ -254,6 +251,13 @@
             </particDesc>
         </profileDesc>
     </teiHeader>
+    <standOff>
+        <listEvent>
+            <event type="print" when="1860"><desc/></event>
+            <event type="premiere" when="1852-11-27"><desc/></event>
+            <event type="written" when="1852"><desc/></event>
+        </listEvent>
+    </standOff>
     <text>
         <front>
             <castList>

--- a/level1/Jokai_DozsaGyorgy.xml
+++ b/level1/Jokai_DozsaGyorgy.xml
@@ -143,9 +143,6 @@
                     </author>
                     <title type="main">Színművek 2. kötet</title>
                     <title type="sub">Dózsa György; Manlius Sinister</title>
-                    <date type="print" when="1860">1860</date>
-                    <date type="premiere" when="1868-01-29">1868-01-29</date>
-                    <date type="written" when="1856">1856</date>
                     <pubPlace>Pest</pubPlace>
                     <publisher/>
                 </bibl>
@@ -236,6 +233,13 @@
             </particDesc>
         </profileDesc>
     </teiHeader>
+    <standOff>
+        <listEvent>
+            <event type="print" when="1860"><desc/></event>
+            <event type="premiere" when="1868-01-29"><desc/></event>
+            <event type="written" when="1856"><desc/></event>
+        </listEvent>
+    </standOff>
     <text>
         <front>
             <castList>

--- a/level1/Jokai_KonyvesKalman.xml
+++ b/level1/Jokai_KonyvesKalman.xml
@@ -143,9 +143,6 @@
                     </author>
                     <title type="main">Színművek 1. kötet</title>
                     <title type="sub">A szigetvári vértanuk; Könyves Kálmán</title>
-                    <date type="print" when="1860">1860</date>
-                    <date type="premiere" when="1855-12-18">1855-12-18</date>
-                    <date type="written" when="1855">1855</date>
                     <pubPlace>Pest</pubPlace>
                     <publisher/>
                 </bibl>
@@ -209,6 +206,13 @@
             </particDesc>
         </profileDesc>
     </teiHeader>
+    <standOff>
+        <listEvent>
+            <event type="print" when="1860"><desc/></event>
+            <event type="premiere" when="1855-12-18"><desc/></event>
+            <event type="written" when="1855"><desc/></event>
+        </listEvent>
+    </standOff>
     <text>
         <front>
             <castList>

--- a/level1/Jokai_Levente.xml
+++ b/level1/Jokai_Levente.xml
@@ -124,9 +124,6 @@
 						</persName>
 						<idno type="wikidata">Q379621</idno>
 					</author>
-					<date type="print" when="1898">1898</date>
-					<date type="premiere"/>
-					<date type="written" when="1897">1897</date>
 					<pubPlace>Pest</pubPlace>
 					<publisher>Révai</publisher>
 				</bibl>
@@ -403,6 +400,12 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1898"><desc/></event>
+			<event type="written" when="1897"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Katona_BankBan.xml
+++ b/level1/Katona_BankBan.xml
@@ -124,9 +124,6 @@
 						</persName>
 						<idno type="wikidata">Q149415</idno>
 					</author>
-					<date type="print" when="1820">1820</date>
-					<date type="premiere" when="1833-02-15">1833-02-15</date>
-					<date type="written" when="1819">1819</date>
 					<publisher>Trattner</publisher>
 					<pubPlace>Budapest</pubPlace>
 				</bibl>
@@ -226,6 +223,13 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1820"><desc/></event>
+			<event type="premiere" when="1833-02-15"><desc/></event>
+			<event type="written" when="1819"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Kisfaludy_AKerok.xml
+++ b/level1/Kisfaludy_AKerok.xml
@@ -116,9 +116,6 @@
 						</persName>
 						<idno type="wikidata">Q927190</idno>
 					</author>
-					<date type="print" when="1820">1820</date>
-					<date type="premiere" when="1819">1819-09-24</date>
-					<date from="1817" to="1819" type="written">1817-1819</date>
 					<pubPlace>Pest</pubPlace>
 					<publisher>unknown</publisher>
 				</bibl>
@@ -178,6 +175,12 @@
 			</textClass>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1820"><desc/></event>
+			<event type="premiere" when="1819"><label>1819-09-24</label></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Kisfaludy_StiborVajda.xml
+++ b/level1/Kisfaludy_StiborVajda.xml
@@ -127,9 +127,6 @@
 					</author>
 					<title type="main">Stibor vajda</title>
 					<title type="sub">dráma</title>
-					<date type="print" when="1820">1820</date>
-					<date type="premiere" when="1819-09">1819-09-07</date>
-					<date type="written" when="1819">1819</date>
 					<pubPlace>Pest</pubPlace>
 					<publisher>Trattner Nyomda</publisher>
 				</bibl>
@@ -193,6 +190,13 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1820"><desc/></event>
+			<event type="premiere" when="1819-09"><label>1819-09-07</label></event>
+			<event type="written" when="1819"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Kovacs_NotlenFerj.xml
+++ b/level1/Kovacs_NotlenFerj.xml
@@ -98,7 +98,6 @@
                             <surname/>
                             <forename/>
                         </persName>
-
                     </respStmt>
                 </bibl>
                 <bibl type="originalSource">
@@ -118,7 +117,6 @@
                             <forename>Lázár</forename>
                         </persName>
                     </respStmt>
-                    <date type="print" when="1843">1843</date>
                     <pubPlace>Buda</pubPlace>
                     <publisher>Magyar Királyi Egyetem nyomdája</publisher>
                 </bibl>
@@ -132,9 +130,6 @@
                     </author>
                     <title type="main"/>
                     <title type="sub"/>
-                    <date type="print"/>
-                    <date type="premiere"/>
-                    <date type="written"/>
                     <pubPlace/>
                     <publisher/>
                 </bibl>
@@ -182,6 +177,11 @@
             </textClass>
         </profileDesc>
     </teiHeader>
+    <standOff>
+        <listEvent>
+            <event type="print" when="1843"><desc/></event>
+        </listEvent>
+    </standOff>
     <text>
         <front>
             <castList>

--- a/level1/Madach_ACivilizator.xml
+++ b/level1/Madach_ACivilizator.xml
@@ -117,9 +117,6 @@
 							<forename>Károly</forename>
 						</persName>
 					</respStmt>
-					<date type="print" when="1880">1880</date>
-					<date type="premiere" when="1938-12-02">1938. december 2.</date>
-					<date type="written" when="1859">1859</date>
 					<pubPlace>Budapest</pubPlace>
 					<publisher>Athenaeum</publisher>
 				</bibl>
@@ -170,6 +167,13 @@
 			</textClass>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1880"><desc/></event>
+			<event type="premiere" when="1938-12-02"><label>1938. december 2.</label></event>
+			<event type="written" when="1859"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Madach_AzEmberTragediaja.xml
+++ b/level1/Madach_AzEmberTragediaja.xml
@@ -107,9 +107,6 @@
 						</persName>
 						<idno type="wikidata">Q366331</idno>
 					</author>
-					<date type="print" when="1861">1861</date>
-					<date type="premiere" when="1883-09-21">1883. szeptember 21.</date>
-					<date from="1859-02-17" to="1860-03-26" type="written">1859. február 17 és 1860. március 26. között</date>
 					<pubPlace>Pest</pubPlace>
 					<publisher>Kisfaludy-Társaság</publisher>
 				</bibl>
@@ -452,6 +449,12 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1861"><desc/></event>
+			<event type="premiere" when="1883-09-21"><label>1883. szeptember 21.</label></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<body>
 			<head type="title">Az ember tragédiája</head>

--- a/level1/Madach_CsakVegnapjai.xml
+++ b/level1/Madach_CsakVegnapjai.xml
@@ -123,9 +123,6 @@
 					</author>
 					<title type="main">Csák végnapjai</title>
 					<title type="sub">Dráma öt felvonásban : Előjátékkal egy felvonásban</title>
-					<date type="print" when="1888">1888</date>
-					<date type="premiere" when="1886">1886-10-09</date>
-					<date from="1843" to="1861" type="written">1843 és 1861 között</date>
 					<pubPlace>Budapest</pubPlace>
 					<publisher>Athenaeum</publisher>
 				</bibl>
@@ -243,6 +240,12 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1888"><desc/></event>
+			<event type="premiere" when="1886"><label>1886-10-09</label></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Madach_FerfiEsNo.xml
+++ b/level1/Madach_FerfiEsNo.xml
@@ -125,9 +125,6 @@
 					</respStmt>
 					<title type="main">Madách Imre Összes Művei</title>
 					<title type="sub"/>
-					<date type="print" when="1888">1888</date>
-					<date type="premiere" when="1892-02-06">1892-02-06</date>
-					<date type="written" when="1843">1843</date>
 					<pubPlace>Budapest</pubPlace>
 					<publisher>Athenaeum</publisher>
 				</bibl>
@@ -176,6 +173,13 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1888"><desc/></event>
+			<event type="premiere" when="1892-02-06"><desc/></event>
+			<event type="written" when="1843"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Madach_Mozes.xml
+++ b/level1/Madach_Mozes.xml
@@ -130,9 +130,6 @@
 							<forename>Pál</forename>
 						</persName>
 					</respStmt>
-					<date type="print" when="1880">1880</date>
-					<date type="premiere" when="1888">1888</date>
-					<date from="1860" to="1861" type="written">1860-1861</date>
 					<pubPlace>Pest</pubPlace>
 					<publisher>Athenaeum</publisher>
 				</bibl>
@@ -225,6 +222,12 @@
 			</textClass>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1880"><desc/></event>
+			<event type="premiere" when="1888"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Moricz_LegyJoMindhalalig.xml
+++ b/level1/Moricz_LegyJoMindhalalig.xml
@@ -124,9 +124,6 @@
 						</persName>
 						<idno type="wikidata">Q227312</idno>
 					</author>
-					<date type="print" when="1941">1941</date>
-					<date type="premiere" when="1929-11-29">1929-11-29</date>
-					<date type="written" when="1929">1929</date>
 					<publisher> Athenaeum</publisher>
 					<pubPlace>Budapest</pubPlace>
 				</bibl>
@@ -244,6 +241,13 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1941"><desc/></event>
+			<event type="premiere" when="1929-11-29"><desc/></event>
+			<event type="written" when="1929"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Moricz_UriMuri.xml
+++ b/level1/Moricz_UriMuri.xml
@@ -118,9 +118,6 @@
 							<forename>Miklós</forename>
 						</persName>
 					</respStmt>
-					<date type="print" when="1954">1954</date>
-					<date type="premiere" when="1942">1928-03-3</date>
-					<date from="1928" to="1942" type="written">1928 és 1942 között</date>
 					<pubPlace>Budapest</pubPlace>
 					<publisher>Művelt Nép</publisher>
 				</bibl>
@@ -232,6 +229,12 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1954"><desc/></event>
+			<event type="premiere" when="1942"><label>1928-03-3</label></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<head>SZEMÉLYEK</head>

--- a/level1/Nagy_Tisztujitas.xml
+++ b/level1/Nagy_Tisztujitas.xml
@@ -117,9 +117,6 @@
 					</author>
 					<title type="main">Tisztújítás</title>
 					<title type="sub">Vígjáték három felvonásban</title>
-					<date type="print" when="1843">1843</date>
-					<date type="premiere" when="1843-08-05">1843-08-05</date>
-					<date type="written" when="1842">1842</date>
 					<pubPlace>Buda</pubPlace>
 					<publisher>Magyar Királyi Egyetem</publisher>
 				</bibl>
@@ -200,6 +197,13 @@
 			</textClass>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1843"><desc/></event>
+			<event type="premiere" when="1843-08-05"><desc/></event>
+			<event type="written" when="1842"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Obernyik_FourEsPor.xml
+++ b/level1/Obernyik_FourEsPor.xml
@@ -120,9 +120,6 @@
                     </author>
                     <title type="main">Főúr és pór</title>
                     <title type="sub">Szomorújáték</title>
-                    <date type="print" when="1844">1844</date>
-                    <date type="premiere" when="1848-05-02">1848-05-02</date>
-                    <date type="written" when="1843">1843</date>
                     <pubPlace>Buda; Pest</pubPlace>
                     <publisher>Egyetemi Nyomda; Eggenberger</publisher>
                 </bibl>
@@ -180,6 +177,13 @@
             </particDesc>
         </profileDesc>
     </teiHeader>
+    <standOff>
+        <listEvent>
+            <event type="print" when="1844"><desc/></event>
+            <event type="premiere" when="1848-05-02"><desc/></event>
+            <event type="written" when="1843"><desc/></event>
+        </listEvent>
+    </standOff>
     <text>
         <front>
             <castList>

--- a/level1/Pekar_MatyasEsBeatrix.xml
+++ b/level1/Pekar_MatyasEsBeatrix.xml
@@ -117,9 +117,6 @@
 						</persName>
 						<idno type="wikidata">Q1232089</idno>
 					</author>
-					<date type="print" when="1904">1904</date>
-					<date type="premiere" when="1904-03-24">1904-03-24</date>
-					<date type="written" when="1904">1904</date>
 					<pubPlace>Budapest</pubPlace>
 					<publisher>Singer - Wolfner</publisher>
 				</bibl>
@@ -279,6 +276,13 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1904"><desc/></event>
+			<event type="premiere" when="1904-03-24"><desc/></event>
+			<event type="written" when="1904"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Petofi_TigrisEsHiena.xml
+++ b/level1/Petofi_TigrisEsHiena.xml
@@ -120,9 +120,6 @@
 					</author>
 					<title type="main">Tigris és hiéna</title>
 					<title type="sub">Történeti dráma négy felvonásban</title>
-					<date type="print" when="1847">1847</date>
-					<date type="premiere" when="1883">1883-11-03</date>
-					<date type="written" when="1847">1847</date>
 					<pubPlace>Pest</pubPlace>
 					<publisher>Emich</publisher>
 				</bibl>
@@ -225,6 +222,13 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1847"><desc/></event>
+			<event type="premiere" when="1883"><label>1883-11-03</label></event>
+			<event type="written" when="1847"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Szakonyi_Adashiba.xml
+++ b/level1/Szakonyi_Adashiba.xml
@@ -122,9 +122,6 @@
 							<forename>Lajosné</forename>
 						</persName>
 					</respStmt>
-					<date type="print" when="1971">1971</date>
-					<date type="premiere" when="1970-05-23">1970-05-23</date>
-					<date type="written" when="1970">1970</date>
 					<pubPlace>Budapest</pubPlace>
 					<publisher>Szépirodalmi Könyvkiadó</publisher>
 				</bibl>
@@ -169,6 +166,13 @@
 			</textClass>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1971"><desc/></event>
+			<event type="premiere" when="1970-05-23"><desc/></event>
+			<event type="written" when="1970"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Szasz_AttilaHalala.xml
+++ b/level1/Szasz_AttilaHalala.xml
@@ -127,9 +127,6 @@
 					</author>
 					<title type="main">Attila halála</title>
 					<title type="sub">Történeti tragédia</title>
-					<date type="print" when="1893">1893</date>
-					<date type="premiere">unknown</date>
-					<date type="written" when="1893">1893</date>
 					<pubPlace>Budapest</pubPlace>
 					<publisher>M. Tut. Akadémia, Franklin Ny.</publisher>
 				</bibl>
@@ -219,6 +216,12 @@
 			</textClass>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1893"><desc/></event>
+			<event type="written" when="1893"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Szigligeti_ALelenc.xml
+++ b/level1/Szigligeti_ALelenc.xml
@@ -127,9 +127,6 @@
 						</persName>
 						<idno type="wikidata">Q897099</idno>
 					</author>
-					<date type="print" when="1879">1879</date>
-					<date type="premiere" when="1863">1863</date>
-					<date type="written" when="1863">1863</date>
 					<pubPlace>Budapest</pubPlace>
 					<publisher>Pfeiffer</publisher>
 				</bibl>
@@ -214,6 +211,13 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1879"><desc/></event>
+			<event type="premiere" when="1863"><desc/></event>
+			<event type="written" when="1863"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Szigligeti_Csikos.xml
+++ b/level1/Szigligeti_Csikos.xml
@@ -129,9 +129,6 @@
                     <title type="main">Szigligeti öszves színművei</title>
                     <title type="sub">7. füzet, Csikós : eredeti népszinmű 3 szakaszban,
                         népdalokkal, tánczokkal</title>
-                    <date type="print" when="1848">1848</date>
-                    <date type="premiere" when="1847">1847</date>
-                    <date type="written" when="1847">1847</date>
                     <pubPlace>Pest</pubPlace>
                     <publisher/>
                 </bibl>
@@ -231,6 +228,13 @@
             </particDesc>
         </profileDesc>
     </teiHeader>
+    <standOff>
+        <listEvent>
+            <event type="print" when="1848"><desc/></event>
+            <event type="premiere" when="1847"><desc/></event>
+            <event type="written" when="1847"><desc/></event>
+        </listEvent>
+    </standOff>
     <text>
         <front>
             <castList>

--- a/level1/Szigligeti_FennAzErnyo.xml
+++ b/level1/Szigligeti_FennAzErnyo.xml
@@ -132,9 +132,6 @@
                     </author>
                     <title type="main">Szökött katona</title>
                     <title type="sub">Népszínmű</title>
-                    <date type="print" when="1843">1843. november 25.</date>
-                    <date type="premiere" when="1847">1847</date>
-                    <date type="written" when="1843">1843</date>
                     <pubPlace>Budapest</pubPlace>
                     <publisher>Szépirodalmi K.</publisher>
                 </bibl>
@@ -182,6 +179,13 @@
             </textClass>
         </profileDesc>
     </teiHeader>
+    <standOff>
+        <listEvent>
+            <event type="print" when="1843"><label>1843. november 25.</label></event>
+            <event type="premiere" when="1847"><desc/></event>
+            <event type="written" when="1843"><desc/></event>
+        </listEvent>
+    </standOff>
     <text>
         <body>
             <div type="act">

--- a/level1/Szigligeti_IIRakocziFerenc.xml
+++ b/level1/Szigligeti_IIRakocziFerenc.xml
@@ -126,9 +126,6 @@
             </persName>
             <idno type="wikidata">Q897099</idno>
           </author>
-          <date type="print" when="1875">1875</date>
-          <date type="premiere" when="1848">1848</date>
-          <date type="written" when="1848">1848</date>
           <pubPlace>Budapest</pubPlace>
           <publisher>Pfeiffer</publisher>
         </bibl>
@@ -255,6 +252,13 @@
       </particDesc>
     </profileDesc>
   </teiHeader>
+    <standOff>
+      <listEvent>
+        <event type="print" when="1875"><desc/></event>
+        <event type="premiere" when="1848"><desc/></event>
+        <event type="written" when="1848"><desc/></event>
+      </listEvent>
+    </standOff>
   <text>
     <front>
       <castList>

--- a/level1/Szigligeti_Liliomfi.xml
+++ b/level1/Szigligeti_Liliomfi.xml
@@ -118,9 +118,6 @@
 						</persName>
 						<idno type="wikidata">Q897099</idno>
 					</author>
-					<date type="print" when="1875">1875</date>
-					<date type="premiere" when="1849-12-21">1849-12-21</date>
-					<date type="written" when="1849">1849</date>
 					<publisher>Franklin</publisher>
 					<pubPlace>Budapest</pubPlace>
 				</bibl>
@@ -192,6 +189,13 @@
 			</textClass>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1875"><desc/></event>
+			<event type="premiere" when="1849-12-21"><desc/></event>
+			<event type="written" when="1849"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Szigligeti_SzokottKatona.xml
+++ b/level1/Szigligeti_SzokottKatona.xml
@@ -120,9 +120,6 @@
                     </author>
                     <title type="main">Szökött katona</title>
                     <title type="sub">Népszínmű</title>
-                    <date type="print" when="1843">1843. november 25.</date>
-                    <date type="premiere" when="1847">1847</date>
-                    <date type="written" when="1843">1843</date>
                     <pubPlace>Budapest</pubPlace>
                     <publisher>Szépirodalmi K.</publisher>
                 </bibl>
@@ -282,6 +279,13 @@
             </particDesc>
         </profileDesc>
     </teiHeader>
+    <standOff>
+        <listEveßnt>
+            <event type="print" when="1843"><label>1843. november 25.</label></event>
+            <event type="premiere" when="1847"><desc/></event>
+            <event type="written" when="1843"><desc/></event>
+        </listEveßnt>
+    </standOff>
     <text>
         <front>
             <p>

--- a/level1/Szigligeti_SzokottKatona.xml
+++ b/level1/Szigligeti_SzokottKatona.xml
@@ -87,12 +87,12 @@
                     <respStmt>
                         <resp>Original Electronic Edition</resp>
                         <persName>
-                            <surname/>Szever 
-                            <forename/>Pál 
+                            <surname>Szever</surname>
+                            <forename>Pál</forename>
                         </persName>
                         <persName>
-                            <surname/>Csige
-                            <forename/>Mónika
+                            <surname>Csige</surname>
+                            <forename>Mónika</forename>
                         </persName>
                     </respStmt>
                 </bibl>

--- a/level1/Teleki_Kegyenc.xml
+++ b/level1/Teleki_Kegyenc.xml
@@ -123,9 +123,6 @@
 						</persName>
 						<idno type="wikidata">Q832633</idno>
 					</author>
-					<date type="print" when="1880">1841</date>
-					<date type="premiere" when="1841-10-06">1841. szeptember 6.</date>
-					<date type="written" when="1840">1840</date>
 					<pubPlace>Pest</pubPlace>
 					<publisher>Heckenast Gusztáv</publisher>
 				</bibl>
@@ -258,6 +255,13 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1880"><label>1841</label></event>
+			<event type="premiere" when="1841-10-06"><label>1841. szeptember 6.</label></event>
+			<event type="written" when="1840"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Toth_AFaluRossza.xml
+++ b/level1/Toth_AFaluRossza.xml
@@ -116,9 +116,6 @@
 						<idno type="wikidata">Q1327111</idno>
 					</author>
 					<title type="main">A falu rossza</title>
-					<date type="print" when="1874">1874</date>
-					<date type="premiere" when="1875-01-15">1875-01-15</date>
-					<date type="written" when="1874">1874</date>
 					<pubPlace>Budapest</pubPlace>
 					<publisher>Pfeifer</publisher>
 				</bibl>
@@ -212,6 +209,13 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1874"><desc/></event>
+			<event type="premiere" when="1875-01-15"><desc/></event>
+			<event type="written" when="1874"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Vorosmarty_AFatyolTitkai.xml
+++ b/level1/Vorosmarty_AFatyolTitkai.xml
@@ -102,10 +102,6 @@
 						</persName>
 						<idno type="wikidata">Q332484</idno>
 					</author>
-					<date type="print" when="1834-10">1834 októberében</date>
-					<date type="premiere" when="1836-03-27">1836. március 27.</date>
-					<date from="1833-03" to="1834-08-15" type="written">1833. márciusa után, 1834.
-						augusztus 15. előtt</date>
 					<pubPlace>Pest</pubPlace>
 					<publisher>Kisfaludy Károly</publisher>
 				</bibl>
@@ -163,6 +159,15 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1834-10"><label>1834 októberében</label></event>
+			<event type="premiere" when="1836-03-27"><label>1836. március 27.</label></event>
+			<event notBefore="1833-03" notAfter="1834-08-15" type="written">
+				1833. márciusa után, 1834. augusztus 15. előtt
+			</event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Vorosmarty_CsongorEsTunde.xml
+++ b/level1/Vorosmarty_CsongorEsTunde.xml
@@ -125,9 +125,6 @@
 					</author>
 					<title type="main">Csongor és Tünde</title>
 					<title type="sub">Színjáték öt felvonásban</title>
-					<date type="print" when="1831">1831</date>
-					<date type="premiere" when="1833-02-15">1833-02-15</date>
-					<date type="written" when="1830">1830</date>
 					<publisher>Számmer Pál</publisher>
 					<pubPlace>Székesfehérvár</pubPlace>
 				</bibl>
@@ -188,6 +185,13 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1831"><desc/></event>
+			<event type="premiere" when="1833-02-15"><desc/></event>
+			<event type="written" when="1830"><desc/></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Vorosmarty_Kincskeresok.xml
+++ b/level1/Vorosmarty_Kincskeresok.xml
@@ -109,10 +109,6 @@
 						</persName>
 						<idno type="wikidata">Q332484</idno>
 					</author>
-					<date type="print" when="1832">1832 ősze</date>
-					<date type="premiere" when="1834-09-16">1834. szeptember 16.</date>
-					<date from="1831-12" to="1832" type="written">1831. decembere és
-                        1832. ősze között</date>
 					<pubPlace>Pest</pubPlace>
 					<publisher>Kisfaludy Károly</publisher>
 				</bibl>
@@ -164,6 +160,15 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1832"><label>1832 ősze</label></event>
+			<event type="premiere" when="1834-09-16"><label>1834. szeptember 16.</label></event>
+			<event notBefore="1831-12" notAfter="1832" type="written">
+				1831. decembere és 1832. ősze között
+			</event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<castList>

--- a/level1/Vorosmarty_Vernasz.xml
+++ b/level1/Vorosmarty_Vernasz.xml
@@ -110,10 +110,6 @@
 						</persName>
 						<idno type="wikidata">Q332484</idno>
 					</author>
-					<date type="print" when="1834-02-26">1834. február 26.</date>
-					<date type="premiere" when="1834-11-08">1834. november 8.</date>
-					<date from="1832-12-19" to="1833-03-24" type="written">1832. december 19. és
-                        1833. március 24. között</date>
 					<pubPlace>Pest</pubPlace>
 					<publisher>Magyar Tudós Társaság</publisher>
 				</bibl>
@@ -180,6 +176,12 @@
 			</particDesc>
 		</profileDesc>
 	</teiHeader>
+	<standOff>
+		<listEvent>
+			<event type="print" when="1834-02-26"><label>1834. február 26.</label></event>
+			<event type="premiere" when="1834-11-08"><label>1834. november 8.</label></event>
+		</listEvent>
+	</standOff>
 	<text>
 		<front>
 			<head type="title">SZEMÉLYEK</head>


### PR DESCRIPTION
This is the new way we encode these dates in DraCor.

This PR includes also some minor markup fixes (472145763050e267e7d840a98345d6852624e41c) I came across while changing the date markup.